### PR TITLE
fix(EAV-84): set format & encoding on connection

### DIFF
--- a/src/inewsFtp.ts
+++ b/src/inewsFtp.ts
@@ -137,6 +137,19 @@ export class INewsClient extends EventEmitter {
 							returned = true
 							this._connectionPromise = undefined
 							this._currentDir = null
+
+							// Set the connection to Unicode.
+							// https://resources.avid.com/SupportFiles/attach/Broadcast/iNEWS-v45-AG.pdf
+							this._ftpConn.site('CHARSET=UTF-8', () => {
+								// Do nothing.
+							})
+
+							// Set the connection to NSML 2 format.
+							// https://resources.avid.com/SupportFiles/attach/Broadcast/iNEWS-v45-AG.pdf
+							this._ftpConn.site('FORMAT=2NSML', () => {
+								// Do nothing.
+							})
+
 							removeListeners()
 							resolve(this._ftpConn)
 						}


### PR DESCRIPTION
This PR intends to make connections to a wider range of iNEWS servers more reliable by manually specifying the encoding and NSML formats to use.